### PR TITLE
Exclude optional DDoS VNet policy assignments

### DIFF
--- a/templates/core/governance/mgmt-groups/landingzones/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/landingzones/main.bicepparam
@@ -14,7 +14,9 @@ param landingZonesConfig = {
   managementGroupIntermediateRootName: 'alz'
   managementGroupDisplayName: 'Landing Zones'
   managementGroupDoNotEnforcePolicyAssignments: []
-  managementGroupExcludedPolicyAssignments: []
+  managementGroupExcludedPolicyAssignments: [
+    'Enable-DDoS-VNET'
+  ]
   customerRbacRoleDefs: []
   customerRbacRoleAssignments: []
   customerPolicyDefs: []
@@ -31,13 +33,6 @@ param landingZonesConfig = {
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
 param parPolicyAssignmentParameterOverrides = {
-  'Enable-DDoS-VNET': {
-    parameters: {
-      ddosPlan: {
-        value: '/subscriptions/021124c7-8f3d-4bd7-a631-21ab942d69e5/resourceGroups/rg-alz-conn-${parLocations[0]}/providers/Microsoft.Network/ddosProtectionPlans/ddos-alz-${parLocations[0]}'
-      }
-    }
-  }
   'Deploy-AzSqlDb-Auditing': {
     parameters: {
       logAnalyticsWorkspaceId: {

--- a/templates/core/governance/mgmt-groups/platform/platform-connectivity/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/platform/platform-connectivity/main.bicepparam
@@ -14,7 +14,9 @@ param platformConnectivityConfig = {
   managementGroupIntermediateRootName: 'alz'
   managementGroupDisplayName: 'Connectivity'
   managementGroupDoNotEnforcePolicyAssignments: []
-  managementGroupExcludedPolicyAssignments: []
+  managementGroupExcludedPolicyAssignments: [
+    'Enable-DDoS-VNET'
+  ]
   customerRbacRoleDefs: []
   customerRbacRoleAssignments: []
   customerPolicyDefs: []
@@ -30,12 +32,4 @@ param platformConnectivityConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
-param parPolicyAssignmentParameterOverrides = {
-  'Enable-DDoS-VNET': {
-    parameters: {
-      ddosPlan: {
-        value: '/subscriptions/021124c7-8f3d-4bd7-a631-21ab942d69e5/resourceGroups/rg-alz-conn-${parLocations[0]}/providers/Microsoft.Network/ddosProtectionPlans/ddos-alz-${parLocations[0]}'
-      }
-    }
-  }
-}
+param parPolicyAssignmentParameterOverrides = {}

--- a/templates/networking/hubnetworking/main.bicep
+++ b/templates/networking/hubnetworking/main.bicep
@@ -815,6 +815,7 @@ type hubVirtualNetworkType = {
   ddosProtectionPlanSettings: ddosProtectionPlanType
 
   @description('Required. The location of the virtual network.')
+  @minLength(1)
   location: string
 
   @description('Optional. Resource ID of an existing DDoS protection plan to associate with the virtual network. If not specified and deployDdosProtectionPlan is true, a new DDoS protection plan will be created.')

--- a/templates/networking/hubnetworking/main.bicepparam
+++ b/templates/networking/hubnetworking/main.bicepparam
@@ -66,7 +66,7 @@ param hubNetworks = [
       }
     ]
     azureFirewallSettings: {
-      deployAzureFirewall: true
+      deployAzureFirewall: false
       azureFirewallName: 'afw-alz-${parLocations[0]}'
       azureSkuTier: 'Standard'
       publicIPAddressObject: {
@@ -77,12 +77,12 @@ param hubNetworks = [
       }
     }
     bastionHostSettings: {
-      deployBastion: true
+      deployBastion: false
       bastionHostSettingsName: 'bas-alz-${parLocations[0]}'
       skuName: 'Standard'
     }
     vpnGatewaySettings: {
-      deployVpnGateway: true
+      deployVpnGateway: false
       name: 'vgw-alz-${parLocations[0]}'
       skuName: 'VpnGw1AZ'
       vpnMode: 'activeActiveBgp'
@@ -90,7 +90,7 @@ param hubNetworks = [
       asn: 65515
     }
     expressRouteGatewaySettings: {
-      deployExpressRouteGateway: true
+      deployExpressRouteGateway: false
       name: 'ergw-alz-${parLocations[0]}'
     }
     privateDnsSettings: {
@@ -100,7 +100,7 @@ param hubNetworks = [
       privateDnsZones: []
     }
     ddosProtectionPlanSettings: {
-      deployDdosProtectionPlan: true
+      deployDdosProtectionPlan: false
       name: 'ddos-alz-${parLocations[0]}'
     }
   }
@@ -150,7 +150,7 @@ param hubNetworks = [
       }
     ]
     azureFirewallSettings: {
-      deployAzureFirewall: true
+      deployAzureFirewall: false
       azureFirewallName: 'afw-alz-${parLocations[1]}'
       azureSkuTier: 'Standard'
       publicIPAddressObject: {
@@ -161,12 +161,12 @@ param hubNetworks = [
       }
     }
     bastionHostSettings: {
-      deployBastion: true
+      deployBastion: false
       bastionHostSettingsName: 'bas-alz-${parLocations[1]}'
       skuName: 'Standard'
     }
     vpnGatewaySettings: {
-      deployVpnGateway: true
+      deployVpnGateway: false
       name: 'vgw-alz-${parLocations[1]}'
       skuName: 'VpnGw1AZ'
       vpnMode: 'activeActiveBgp'
@@ -174,7 +174,7 @@ param hubNetworks = [
       asn: 65515
     }
     expressRouteGatewaySettings: {
-      deployExpressRouteGateway: true
+      deployExpressRouteGateway: false
       name: 'ergw-alz-${parLocations[1]}'
     }
     privateDnsSettings: {

--- a/templates/networking/hubnetworking/main.bicepparam
+++ b/templates/networking/hubnetworking/main.bicepparam
@@ -3,7 +3,7 @@ using './main.bicep'
 // General Parameters
 param parLocations = [
   'swedencentral'
-  ''
+  'northeurope'
 ]
 param parGlobalResourceLock = {
   name: 'GlobalResourceLock'


### PR DESCRIPTION
## Summary
This change removes the governance-side dependency on an Azure DDoS Network Protection plan when hub networking is configured not to deploy one.

## What changed
- Excluded `Enable-DDoS-VNET` from platform connectivity policy assignments
- Excluded `Enable-DDoS-VNET` from landing zones policy assignments
- Removed the hard-coded DDoS plan parameter override from both governance parameter files
- Excluded `Enable-DDoS-VNET` from the cross-management-group RBAC parameter files for platform and landing zones

## Why
Hub networking does not deploy a DDoS plan, but the governance layer was still assigning `Enable-DDoS-VNET` with a reference to a specific DDoS plan resource ID. The cross-management-group RBAC modules also referenced that assignment as an existing resource to resolve its managed identity. Together, that could cause deployment failures with `NotFound` for the missing plan or missing assignment.

## Result
- No DDoS plan is required
- No paid Azure DDoS Network Protection resource will be deployed
- Governance policy no longer forces a reference to a non-existent DDoS plan
- Cross-management-group RBAC no longer looks up the excluded DDoS policy assignment

## Validation
- The edited parameter files validate without errors
